### PR TITLE
Bug fix for memory leakage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pdf
 *.jpg
 *.html
+*.json

--- a/Saturation/Plots/sca15_filled_vs_beam_energy/.vscode/settings.json
+++ b/Saturation/Plots/sca15_filled_vs_beam_energy/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "EventControl.C": "cpp",
-        "EventControl1.C": "cpp"
-    }
-}

--- a/Saturation/Plots/sca15_filled_vs_beam_energy/EventControl.C
+++ b/Saturation/Plots/sca15_filled_vs_beam_energy/EventControl.C
@@ -66,7 +66,7 @@ float EventControl::Count_Event()
 
    float scale = static_cast<float>(cnt) / static_cast<float>(total_hits);
    cout << "scale = " << scale << endl;
-   return static_cast<float>(cnt);
+   return static_cast<float>(scale);
    // return scale;
    
 } // event loop

--- a/Saturation/Plots/sca15_filled_vs_beam_energy/EventControl.h
+++ b/Saturation/Plots/sca15_filled_vs_beam_energy/EventControl.h
@@ -36,21 +36,21 @@ public :
    Int_t           nhit_len;
    Float_t         sum_energy;
    Float_t         sum_energy_lg;
-   Int_t           hit_slab[1453];   //[nhit_len]
-   Int_t           hit_chip[1453];   //[nhit_len]
-   Int_t           hit_chan[1453];   //[nhit_len]
-   Int_t           hit_sca[1453];   //[nhit_len]
-   Float_t         hit_x[1453];   //[nhit_len]
-   Float_t         hit_y[1453];   //[nhit_len]
-   Float_t         hit_z[1453];   //[nhit_len]
-   Int_t           hit_adc_high[1453];   //[nhit_len]
-   Int_t           hit_adc_low[1453];   //[nhit_len]
-   Float_t         hit_energy[1453];   //[nhit_len]
-   Float_t         hit_energy_lg[1453];   //[nhit_len]
-   Int_t           hit_n_scas_filled[1453];   //[nhit_len]
-   Int_t           hit_isHit[1453];   //[nhit_len]
-   Int_t           hit_isMasked[1453];   //[nhit_len]
-   Int_t           hit_isCommissioned[1453];   //[nhit_len]
+   Int_t           hit_slab[9999];   //[nhit_len]
+   Int_t           hit_chip[9999];   //[nhit_len]
+   Int_t           hit_chan[9999];   //[nhit_len]
+   Int_t           hit_sca[9999];   //[nhit_len]
+   Float_t         hit_x[9999];   //[nhit_len]
+   Float_t         hit_y[9999];   //[nhit_len]
+   Float_t         hit_z[9999];   //[nhit_len]
+   Int_t           hit_adc_high[9999];   //[nhit_len]
+   Int_t           hit_adc_low[9999];   //[nhit_len]
+   Float_t         hit_energy[9999];   //[nhit_len]
+   Float_t         hit_energy_lg[9999];   //[nhit_len]
+   Int_t           hit_n_scas_filled[9999];   //[nhit_len]
+   Int_t           hit_isHit[9999];   //[nhit_len]
+   Int_t           hit_isMasked[9999];   //[nhit_len]
+   Int_t           hit_isCommissioned[9999];   //[nhit_len]
 
    // List of branches
    TBranch        *b_event;   //!
@@ -103,9 +103,9 @@ EventControl::EventControl(TTree *tree) : fChain(0)
 // if parameter tree is not specified (or zero), connect the file
 // used to generate this class and read the Tree.
    if (tree == 0) {
-      TFile *f = (TFile*)gROOT->GetListOfFiles()->FindObject("/home/irles/Work/Saturation/Runs/100GeV.root");
+      TFile *f = (TFile*)gROOT->GetListOfFiles()->FindObject("../../Runs/100GeV.root");
       if (!f || !f->IsOpen()) {
-         f = new TFile("/home/irles/Work/Saturation/Runs/100GeV.root");
+         f = new TFile("../../Runs/100GeV.root");
       }
       f->GetObject("ecal",tree);
 
@@ -119,9 +119,9 @@ EventControl::EventControl(TString filename) : fChain(0)
 // used to generate this class and read the Tree.
    TTree *tree = 0;
    if (filename == "default") {
-      TFile *f = (TFile*)gROOT->GetListOfFiles()->FindObject("/home/irles/Work/Saturation/Runs/100GeV.root");
+      TFile *f = (TFile*)gROOT->GetListOfFiles()->FindObject("../../Runs/100GeV.root");
       if (!f || !f->IsOpen()) {
-         f = new TFile("/home/irles/Work/Saturation/Runs/100GeV.root");
+         f = new TFile("../../Runs/100GeV.root");
       }
       f->GetObject("ecal",tree);
    }else{

--- a/Saturation/Plots/sca15_filled_vs_beam_energy/run.cc
+++ b/Saturation/Plots/sca15_filled_vs_beam_energy/run.cc
@@ -4,37 +4,32 @@
 
 #include "EventControl.C"
 
-float looper(int set_ene = 10){
-
-	TString fname = "/home/irles/Work/Saturation/Runs/" + to_string(set_ene) + "GeV.root";
-	EventControl *evcontrol = new EventControl(fname);
-	float count = evcontrol->Count_Event();
-	cout << "success with " << fname << endl;
-
-	return count;
-
-
-}
-
 void run(){
 
-	// const int nene = 7;
-	// int l_energy[nene] = {10,20,40,60,80,100,150};
-	const int nene = 4;
-	int l_energy[nene] = {60,80,100,150};
+	const int nene = 7;
+	int l_energy[nene] = {10,20,40,60,80,100,150};
 
-	TFile *MyFile = new TFile("output2.root","RECREATE");
+	TFile *MyFile = new TFile("output.root","RECREATE");
 	TH1F *h_cnt = new TH1F("h_cnt","Hits above sca 13;Energy (GeV);nHits",16,-5,155);
-	h_cnt->Sumw2();
 
 	for(int ie=0; ie<nene; ie++)
 	{
-		float number = looper(l_energy[ie]);
-		h_cnt->Fill(l_energy[ie],number);
+		TString filepath = "../../Runs/";
+		TString filename = to_string(l_energy[ie]) + "GeV.root";
+		TString fullname = filepath + filename;
+		EventControl EventControl(fullname);
+		float count = EventControl.Count_Event();
+		h_cnt->Fill(l_energy[ie],count);
 	}
 
-	// h_cnt->Draw("h");
+	ROOT::Math::MinimizerOptions::SetDefaultMaxFunctionCalls( 200 );
+
+	h_cnt->Draw("h");
 	MyFile->cd();
 	h_cnt->Write();
+
+	gSystem->Exit(0);
+
+	// return 0;
 
 }


### PR DESCRIPTION
## Problem reporting
### What happened?
- Some runs were not being able to iterate through despite being able to execute with different runs.
- I.e. 80 GeV run could not be completed with a one go.
- Potential memory leak?
### Inspection
- Attempted executing with individual runs.
- 10, 20 GeV were typically safe. 40 GeV and beyond were buggy.
- Error tells segmentation violation and the error messages were little to no help
### Solution
- Number of hits expected for different runs do vary.
- For example, 80 GeV has max. of more than 2,000 hits while array expects only 1400.
- Hard coded the array number to be `9999` yet this might not be the solid solution. (see e14cf4d75f78139d3a1951f0d840cb31a36198ae)